### PR TITLE
신고 API 구현

### DIFF
--- a/src/main/java/project/mbti/exception/AlreadyCompletedReportException.java
+++ b/src/main/java/project/mbti/exception/AlreadyCompletedReportException.java
@@ -1,0 +1,10 @@
+package project.mbti.exception;
+
+import project.mbti.response.error.ErrorCode;
+
+public class AlreadyCompletedReportException extends BusinessException {
+
+    public AlreadyCompletedReportException() {
+        super(ErrorCode.ALREADY_COMPLETED_REPORT);
+    }
+}

--- a/src/main/java/project/mbti/exception/AlreadyDeletedCommentException.java
+++ b/src/main/java/project/mbti/exception/AlreadyDeletedCommentException.java
@@ -1,0 +1,10 @@
+package project.mbti.exception;
+
+import project.mbti.response.error.ErrorCode;
+
+public class AlreadyDeletedCommentException extends BusinessException {
+
+    public AlreadyDeletedCommentException() {
+        super(ErrorCode.ALREADY_DELETED_COMMENT);
+    }
+}

--- a/src/main/java/project/mbti/exception/InvalidMbtiException.java
+++ b/src/main/java/project/mbti/exception/InvalidMbtiException.java
@@ -1,0 +1,9 @@
+package project.mbti.exception;
+
+import project.mbti.response.error.ErrorCode;
+
+public class InvalidMbtiException extends BusinessException {
+    public InvalidMbtiException() {
+        super(ErrorCode.INVALID_MBTI);
+    }
+}

--- a/src/main/java/project/mbti/exception/InvalidReportStateException.java
+++ b/src/main/java/project/mbti/exception/InvalidReportStateException.java
@@ -1,0 +1,10 @@
+package project.mbti.exception;
+
+import project.mbti.response.error.ErrorCode;
+
+public class InvalidReportStateException extends BusinessException {
+
+    public InvalidReportStateException() {
+        super(ErrorCode.INVALID_REPORT_STATE);
+    }
+}

--- a/src/main/java/project/mbti/exception/InvalidReportSubjectException.java
+++ b/src/main/java/project/mbti/exception/InvalidReportSubjectException.java
@@ -1,0 +1,10 @@
+package project.mbti.exception;
+
+import project.mbti.response.error.ErrorCode;
+
+public class InvalidReportSubjectException extends BusinessException {
+
+    public InvalidReportSubjectException() {
+        super(ErrorCode.INVALID_REPORT_SUBJECT);
+    }
+}

--- a/src/main/java/project/mbti/exception/MbtiNotFoundException.java
+++ b/src/main/java/project/mbti/exception/MbtiNotFoundException.java
@@ -1,9 +1,0 @@
-package project.mbti.exception;
-
-import project.mbti.response.error.ErrorCode;
-
-public class MbtiNotFoundException extends BusinessException {
-    public MbtiNotFoundException() {
-        super(ErrorCode.MBTI_NOT_FOUND);
-    }
-}

--- a/src/main/java/project/mbti/exception/ReportNotFoundException.java
+++ b/src/main/java/project/mbti/exception/ReportNotFoundException.java
@@ -1,0 +1,10 @@
+package project.mbti.exception;
+
+import project.mbti.response.error.ErrorCode;
+
+public class ReportNotFoundException extends BusinessException{
+
+    public ReportNotFoundException() {
+        super(ErrorCode.REPORT_NOT_FOUND);
+    }
+}

--- a/src/main/java/project/mbti/report/ReportController.java
+++ b/src/main/java/project/mbti/report/ReportController.java
@@ -1,0 +1,86 @@
+package project.mbti.report;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+import project.mbti.report.dto.ReportDto;
+import project.mbti.report.dto.ReportProcessDto;
+import project.mbti.report.entity.ReportState;
+import project.mbti.response.result.ResultResponse;
+import project.mbti.report.dto.ReportSlackDto;
+import project.mbti.report.dto.ReportWriteDto;
+
+import javax.validation.constraints.NotNull;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.http.HttpMethod.POST;
+import static project.mbti.response.result.ResultCode.*;
+
+@Api(tags = "신고 API")
+@RestController
+@RequiredArgsConstructor
+public class ReportController {
+
+    // TODO: 댓글 신고 처리 시, 해당 댓글 달은 ip 차단하는 방식?
+    //  HttpServletRequest.getRemoteAddr() -> DB에 추가하는 방식 (신고 당한 ip나 신고 악용하는 유저 차단)
+    @Value("${webhook.slack.url}")
+    private String url;
+
+    private final ReportService reportService;
+
+    @ApiOperation(value = "댓글 신고")
+    @PostMapping("/report")
+    public ResponseEntity<ResultResponse> report(@Validated @RequestBody ReportWriteDto dto) {
+        final ReportSlackDto reportSlackDto = reportService.create(dto);
+
+        RestTemplate restTemplate = new RestTemplate();
+        Map<String, Object> request = new HashMap<>();
+        request.put("text",
+                "🔥🔥🔥🔥🔥  새로운 신고가 접수되었어요!  🔥🔥🔥🔥🔥\n\n" +
+                "#️⃣ 신고 id: " + reportSlackDto.getReportId() + "\n" +
+                "✅ 신고 유형: " + reportSlackDto.getSubject().getName() + "\n" +
+                "😫 신고 사유: " + reportSlackDto.getDescription() + "\n\n" +
+                "#️⃣ 댓글 id: " + reportSlackDto.getCommentId() + "\n" +
+                "🤬 댓글 내용: " + reportSlackDto.getCommentContent());
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request);
+        restTemplate.exchange(url, POST, entity, String.class);
+
+        return ResponseEntity.ok()
+                .body(ResultResponse.of(WRITE_REPORT_SUCCESS, reportSlackDto));
+    }
+
+    @ApiOperation(value = "신고 페이징 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "한 페이지 신고 갯수", example = "5", required = true),
+    })
+    @GetMapping("/report")
+    public ResponseEntity<ResultResponse> reportList(@Validated @NotNull(message = "페이지를 입력해주세요.") @RequestParam int page,
+                                                     @Validated @NotNull(message = "댓글 개수를 입력해주세요.") @RequestParam int size,
+                                                     @Validated @NotNull(message = "신고 상태를 입력해주세요.") @RequestParam ReportState state) {
+        final Page<ReportDto> reportPage = reportService.getReportPage(page, size, state);
+
+        return ResponseEntity.ok()
+                .body(ResultResponse.of(FIND_REPORT_PAGE_SUCCESS, reportPage));
+    }
+
+    @ApiOperation(value = "신고 처리")
+    @PatchMapping("/report")
+    public ResponseEntity<ResultResponse> process(@Validated @RequestBody ReportProcessDto dto) {
+        final ReportDto reportDto = reportService.process(dto);
+
+        return ResponseEntity.ok()
+                .body(ResultResponse.of(PROCESS_REPORT_SUCCESS, reportDto));
+    }
+}

--- a/src/main/java/project/mbti/report/ReportRepository.java
+++ b/src/main/java/project/mbti/report/ReportRepository.java
@@ -1,0 +1,27 @@
+package project.mbti.report;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import project.mbti.report.dto.ReportDto;
+import project.mbti.report.entity.Report;
+import project.mbti.report.entity.ReportState;
+
+import java.util.List;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    @Query("select new project.mbti.report.dto." +
+            "ReportDto(r.id, r.subject, r.description, r.state, r.comment.id, r.comment.content, r.comment.state) " +
+            "from Report r " +
+            "join r.comment c " +
+            "where r.state = :state")
+    Page<ReportDto> findReportDtoPage(Pageable pageable, @Param("state") ReportState state);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Report r set r.state = 'CANCELED' where r.comment.id = :commentId and r.state = 'REPORTED'")
+    void bulkUpdateReportStateByCommentId(@Param("commentId") Long commentId);
+}

--- a/src/main/java/project/mbti/report/ReportService.java
+++ b/src/main/java/project/mbti/report/ReportService.java
@@ -1,0 +1,92 @@
+package project.mbti.report;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.mbti.comment.CommentRepository;
+import project.mbti.exception.AlreadyDeletedCommentException;
+import project.mbti.comment.entity.Comment;
+import project.mbti.exception.*;
+import project.mbti.report.dto.*;
+import project.mbti.report.entity.Report;
+import project.mbti.report.entity.ReportState;
+import project.mbti.report.entity.ReportSubject;
+
+import static org.springframework.data.domain.Sort.Direction.ASC;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+import static project.mbti.comment.entity.CommentState.*;
+import static project.mbti.report.entity.ReportState.*;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public ReportSlackDto create(ReportWriteDto dto) {
+        if (dto.getSubject().equals(ReportSubject.NOT_FOUND))
+            throw new InvalidReportSubjectException();
+
+        final Comment comment = commentRepository.findById(dto.getCommentId()).orElseThrow(CommentNotFoundException::new);
+
+        Report report = Report.builder()
+                .comment(comment)
+                .subject(dto.getSubject())
+                .description(dto.getDescription())
+                .build();
+
+        reportRepository.save(report);
+
+        return ReportSlackDto.builder()
+                .reportId(report.getId())
+                .subject(dto.getSubject())
+                .description(dto.getDescription())
+                .commentId(comment.getId())
+                .commentContent(comment.getContent())
+                .build();
+    }
+
+    public Page<ReportDto> getReportPage(int page, int size, ReportState state) {
+        page = (page == 0 ? 0 : page - 1);
+        Direction direction = state.equals(REPORTED) ? ASC : DESC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, "id"));
+        return reportRepository.findReportDtoPage(pageable, state);
+    }
+
+    // TODO: 신고 처리할 때, 사유도 적는 걸로? -> 혹시나 필요할 때, 확인 용도
+    @Transactional
+    public ReportDto process(ReportProcessDto dto) {
+        final Report report = reportRepository.findById(dto.getReportId()).orElseThrow(ReportNotFoundException::new);
+
+        if (report.getState().equals(COMPLETED))
+            throw new AlreadyCompletedReportException();
+        if (dto.getState().equals(REPORTED) || dto.getState().equals(NOT_FOUND))
+            throw new InvalidReportStateException();
+        if (report.getComment().getState().equals(DELETED))
+            throw new AlreadyDeletedCommentException();
+
+        report.updateState(dto.getState());
+        if (dto.getState().equals(COMPLETED)) {
+            report.getComment().updateState(DELETED);
+            reportRepository.bulkUpdateReportStateByCommentId(report.getComment().getId());
+        }
+
+        return ReportDto.builder()
+                .reportId(report.getId())
+                .subject(report.getSubject())
+                .description(report.getDescription())
+                .reportState(report.getState())
+                .commentId(report.getComment().getId())
+                .commentContent(report.getComment().getContent())
+                .commentState(report.getComment().getState())
+                .build();
+    }
+}

--- a/src/main/java/project/mbti/report/dto/ReportDto.java
+++ b/src/main/java/project/mbti/report/dto/ReportDto.java
@@ -1,0 +1,42 @@
+package project.mbti.report.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import project.mbti.comment.entity.CommentState;
+import project.mbti.report.entity.ReportState;
+import project.mbti.report.entity.ReportSubject;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@ApiModel(description = "신고 응답 데이터 모델")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+public class ReportDto {
+
+    @ApiModelProperty(value = "신고 PK", example = "2")
+    private Long reportId;
+
+    @ApiModelProperty(value = "신고 유형", example = "욕설/비하")
+    private ReportSubject subject;
+
+    @ApiModelProperty(value = "신고 사유", example = "너무 심한 욕설이에요!")
+    private String description;
+
+    @ApiModelProperty(value = "신고 상태", example = "REPORTED")
+    private ReportState reportState;
+
+    @ApiModelProperty(value = "댓글 PK", example = "1")
+    private Long commentId;
+
+    @ApiModelProperty(value = "댓글 내용", example = "ㅅ1방")
+    private String commentContent;
+
+    @ApiModelProperty(value = "댓글 상태", example = "DELETED")
+    private CommentState commentState;
+}

--- a/src/main/java/project/mbti/report/dto/ReportProcessDto.java
+++ b/src/main/java/project/mbti/report/dto/ReportProcessDto.java
@@ -1,0 +1,22 @@
+package project.mbti.report.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+import project.mbti.report.entity.ReportState;
+
+import javax.validation.constraints.NotNull;
+
+@ApiModel(description = "신고 처리 데이터 모델")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportProcessDto {
+
+    @ApiModelProperty(value = "신고 PK", example = "1", required = true)
+    @NotNull(message = "신고 PK는 필수입니다.")
+    private Long reportId;
+
+    @ApiModelProperty(value = "신고 상태", example = "COMPLETED", required = true, notes = "COMPLETED 혹은 CANCELED만 입력해주세요. ")
+    @NotNull(message = "처리하려는 신고 상태는 필수입니다.")
+    private ReportState state;
+}

--- a/src/main/java/project/mbti/report/dto/ReportSlackDto.java
+++ b/src/main/java/project/mbti/report/dto/ReportSlackDto.java
@@ -1,0 +1,18 @@
+package project.mbti.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import project.mbti.report.entity.ReportSubject;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ReportSlackDto {
+
+    private Long reportId;
+    private ReportSubject subject;
+    private String description;
+    private Long commentId;
+    private String commentContent;
+}

--- a/src/main/java/project/mbti/report/dto/ReportWriteDto.java
+++ b/src/main/java/project/mbti/report/dto/ReportWriteDto.java
@@ -1,0 +1,29 @@
+package project.mbti.report.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+import org.hibernate.validator.constraints.Length;
+import project.mbti.report.entity.ReportSubject;
+
+import javax.validation.constraints.NotNull;
+
+@ApiModel(description = "신고 요청 데이터 모델")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportWriteDto {
+
+    @ApiModelProperty(value = "댓글 PK", example = "1", required = true)
+    @NotNull(message = "댓글 PK는 필수입니다.")
+    private Long commentId;
+
+    @ApiModelProperty(value = "신고 유형", example = "ABUSE", required = true)
+    @NotNull(message = "신고 유형은 필수입니다.")
+    private ReportSubject subject;
+
+    @ApiModelProperty(value = "신고 사유", example = "너무 심한 욕설이에요!")
+    @Length(max = 500, message = "신고 사유는 500자 이하로 입력해주세요.")
+    private String description;
+}

--- a/src/main/java/project/mbti/report/entity/Report.java
+++ b/src/main/java/project/mbti/report/entity/Report.java
@@ -1,0 +1,58 @@
+package project.mbti.report.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import project.mbti.comment.entity.Comment;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+import static javax.persistence.EnumType.STRING;
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "reports")
+@EntityListeners(AuditingEntityListener.class)
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Enumerated(value = STRING)
+    private ReportSubject subject;
+
+    @Lob
+    private String description;
+
+    @Enumerated(value = STRING)
+    private ReportState state;
+
+    @CreatedDate
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @Builder
+    public Report(Comment comment, ReportSubject subject, String description) {
+        this.comment = comment;
+        this.subject = subject;
+        this.description = description;
+        this.state = ReportState.REPORTED;
+    }
+
+    public void updateState(ReportState state) {
+        this.state = state;
+    }
+}

--- a/src/main/java/project/mbti/report/entity/ReportState.java
+++ b/src/main/java/project/mbti/report/entity/ReportState.java
@@ -1,0 +1,17 @@
+package project.mbti.report.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum ReportState {
+    REPORTED, COMPLETED, CANCELED,
+    NOT_FOUND;
+
+    @JsonCreator
+    public static ReportState getEnumFromValue(String value) {
+        try {
+            return ReportState.valueOf(value);
+        } catch (Exception e) {
+            return NOT_FOUND;
+        }
+    }
+}

--- a/src/main/java/project/mbti/report/entity/ReportSubject.java
+++ b/src/main/java/project/mbti/report/entity/ReportSubject.java
@@ -1,0 +1,30 @@
+package project.mbti.report.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+@Getter
+public enum ReportSubject {
+    ABUSE("욕설/비하"),
+    PORNOGRAPHY("음란물/불건전한 대화"),
+    COMMERCIAL("상업적 광고/판매"),
+    PAPERING("낚시/도배"),
+    DISPUTE("지나친 정치/종교 논쟁"),
+    PROMOTION("불법 홍보"),
+    NOT_FOUND("");
+
+    @JsonCreator
+    public static ReportSubject getEnumFromValue(String value) {
+        try {
+            return ReportSubject.valueOf(value);
+        } catch (Exception e) {
+            return NOT_FOUND;
+        }
+    }
+
+    private final String name;
+
+    ReportSubject(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/project/mbti/response/error/ErrorCode.java
+++ b/src/main/java/project/mbti/response/error/ErrorCode.java
@@ -17,9 +17,16 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(400, "C001", "존재하지 않는 댓글입니다."),
     COMMENT_NAME_NOT_MATCH(400, "C002", "댓글 작성자 이름이 일치하지 않습니다."),
     COMMENT_PASSWORD_NOT_MATCH(400, "C003", "댓글 비밀번호가 일치하지 않습니다."),
+    ALREADY_DELETED_COMMENT(400, "C004", "이미 삭제된 댓글입니다."),
 
     // MBTI
-    MBTI_NOT_FOUND(400, "M001", "올바르지 않은 MBTI 유형입니다."),
+    INVALID_MBTI(400, "M001", "유효하지 않은 MBTI 유형입니다."),
+
+    // Report
+    REPORT_NOT_FOUND(400, "R001", "존재하지 않는 신고입니다."),
+    INVALID_REPORT_SUBJECT(400, "R002", "유효하지 않은 신고 유형입니다."),
+    INVALID_REPORT_STATE(400, "R003", "유효하지 않은 신고 상태입니다."),
+    ALREADY_COMPLETED_REPORT(400, "R003", "이미 처리된 신고입니다."),
     ;
 
     private int status;

--- a/src/main/java/project/mbti/response/result/ResultCode.java
+++ b/src/main/java/project/mbti/response/result/ResultCode.java
@@ -8,15 +8,19 @@ import lombok.Getter;
 public enum ResultCode {
 
     // Comment
-    WRITE_SUCCESS(200,"C100", "댓글 작성 성공"),
-    DELETE_SUCCESS(200,"C101", "댓글 삭제 성공"),
+    WRITE_COMMENT_SUCCESS(200,"C100", "댓글 작성 성공"),
+    DELETE_COMMENT_SUCCESS(200,"C101", "댓글 삭제 성공"),
     FIND_COMMENT_PAGE_SUCCESS(200,"C102", "댓글 페이징 조회 성공"),
     FIND_REPLY_PAGE_SUCCESS(200,"C103", "대댓글 페이징 조회 성공"),
 
-
-    // TEST
+    // Test
     GET_TEST_COUNT_SUCCESS(200, "T001", "테스트 참여 횟수 조회 성공"),
     ANALYSIS_TEST_SUCCESS(200, "T002", "테스트 분석 성공"),
+
+    // Report
+    WRITE_REPORT_SUCCESS(200, "R001", "댓글 신고 성공"),
+    FIND_REPORT_PAGE_SUCCESS(200, "R002", "신고 페이징 조회 성공"),
+    PROCESS_REPORT_SUCCESS(200, "R003", "신고 처리 성공"),
     ;
 
     private int status;

--- a/src/main/java/project/mbti/test/dto/TestCodeDto.java
+++ b/src/main/java/project/mbti/test/dto/TestCodeDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Pattern;
 
-@ApiModel(value = "테스트 코드 요청 데이터 모델")
+@ApiModel(description = "테스트 코드 요청 데이터 모델")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TestCodeDto {


### PR DESCRIPTION
## 변경 사항
### 신고 API
- **신고 Entity** 생성
- **댓글 신고 API** 구현
    - `Slack Incoming Webhook` 추가
- **신고 처리 API** 구현
- **신고 페이징 조회 API** 구현
    - `신고 상태`에 따라 조회 가능
### Swagger API 명세서 에러 수정
- **TestCodeDto**: `@ApiModel` 속성 value -> `description` 변경
    - value에 한글 들어가면, SwaggerHub에서 명세서 빌드할 때 에러 발생
### MBTI 비즈니스 예외명 변경
- MbtiNotFoundException -> `InvalidMbtiException`
    - **NotFound** -> `Entity` 대상
    - **Invalid** -> 유효하지 않은 입력 대상