### PR TITLE
Feat: 댓글 API 로직 수정

### DIFF
--- a/src/main/java/project/mbti/comment/CommentController.java
+++ b/src/main/java/project/mbti/comment/CommentController.java
@@ -31,7 +31,7 @@ public class CommentController {
         final CommentDto commentDto = comment.convert();
 
         return ResponseEntity.ok()
-                .body(ResultResponse.of(WRITE_SUCCESS, commentDto));
+                .body(ResultResponse.of(WRITE_COMMENT_SUCCESS, commentDto));
     }
 
     @ApiOperation(value = "대댓글 작성")
@@ -41,7 +41,7 @@ public class CommentController {
         final CommentDto commentDto = comment.convert();
 
         return ResponseEntity.ok()
-                .body(ResultResponse.of(WRITE_SUCCESS, commentDto));
+                .body(ResultResponse.of(WRITE_COMMENT_SUCCESS, commentDto));
     }
 
     @ApiOperation(value = "댓글 삭제")
@@ -50,7 +50,7 @@ public class CommentController {
         commentService.delete(dto.getId(), dto.getName(), dto.getPassword());
 
         return ResponseEntity.ok()
-                .body(ResultResponse.of(DELETE_SUCCESS, null));
+                .body(ResultResponse.of(DELETE_COMMENT_SUCCESS, null));
     }
 
     @ApiOperation(value = "댓글 페이징 조회")

--- a/src/main/java/project/mbti/comment/CommentRepository.java
+++ b/src/main/java/project/mbti/comment/CommentRepository.java
@@ -14,7 +14,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("select new project.mbti.comment.dto." +
             "CommentDto(c.id, c.parent.id, c.createdDate, c.mbti, c.name, c.password, c.content, c.children.size - 1) " +
             "from Comment c " +
-            "where c.id = c.parent.id")
+            "where c.id = c.parent.id and c.state = 'WRITTEN'")
     Page<CommentDto> findCommentDtoPage(Pageable pageable);
 
     @Query("select new project.mbti.comment.dto." +

--- a/src/main/java/project/mbti/comment/entity/Comment.java
+++ b/src/main/java/project/mbti/comment/entity/Comment.java
@@ -73,4 +73,8 @@ public class Comment {
                 .content(getContent())
                 .build();
     }
+
+    public void updateState(CommentState state) {
+        this.state = state;
+    }
 }


### PR DESCRIPTION
## 변경 사항
- 댓글 엔티티 삭제 -> 댓글 상태 DELETED로 변경
    - 해당 댓글에 접수된 신고들 모두 CANCELED로 벌크 업데이트 쿼리 실행
- 댓글 엔티티 상태 변경 비즈니스 메소드 추가
- ResultCode 댓글 관련 코드 네이밍 명시적으로 수정
- 댓글 페이징 조회 시, WRITTEN 상태만 조회하도록 수정

Resolve: #30