### PR TITLE
Refactor: 댓글 삭제 API HTTP Method 변경

### DIFF
--- a/src/main/java/project/mbti/comment/CommentController.java
+++ b/src/main/java/project/mbti/comment/CommentController.java
@@ -45,12 +45,13 @@ public class CommentController {
     }
 
     @ApiOperation(value = "댓글 삭제")
-    @DeleteMapping("/comment")
+    @PatchMapping("/comment")
     public ResponseEntity<ResultResponse> delete(@Validated @RequestBody CommentDeleteDto dto) {
-        commentService.delete(dto.getId(), dto.getName(), dto.getPassword());
+        final Comment comment = commentService.delete(dto.getId(), dto.getName(), dto.getPassword());
+        final CommentDto commentDto = comment.convert();
 
         return ResponseEntity.ok()
-                .body(ResultResponse.of(DELETE_COMMENT_SUCCESS, null));
+                .body(ResultResponse.of(DELETE_COMMENT_SUCCESS, commentDto));
     }
 
     @ApiOperation(value = "댓글 페이징 조회")
@@ -59,8 +60,9 @@ public class CommentController {
             @ApiImplicitParam(name = "size", value = "댓글 개수", example = "5", required = true)
     })
     @GetMapping("/comment")
-    public ResponseEntity<ResultResponse> commentList(@Validated @NotNull(message = "페이지를 입력해주세요.") @RequestParam int page,
-                                                      @Validated @NotNull(message = "댓글 개수를 입력해주세요.") @RequestParam int size) {
+    public ResponseEntity<ResultResponse> commentList(
+            @Validated @NotNull(message = "페이지를 입력해주세요.") @RequestParam int page,
+            @Validated @NotNull(message = "댓글 개수를 입력해주세요.") @RequestParam int size) {
         final Page<CommentDto> commentPage = commentService.getCommentPage(page, size);
 
         return ResponseEntity.ok()

--- a/src/main/java/project/mbti/comment/CommentRepository.java
+++ b/src/main/java/project/mbti/comment/CommentRepository.java
@@ -12,7 +12,7 @@ import project.mbti.comment.entity.Comment;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("select new project.mbti.comment.dto." +
-            "CommentDto(c.id, c.parent.id, c.createdDate, c.mbti, c.name, c.password, c.content, c.children.size - 1) " +
+            "CommentDto(c.id, c.createdDate, c.mbti, c.name, c.password, c.content, c.children.size - 1, c.state) " +
             "from Comment c " +
             "where c.id = c.parent.id and c.state = 'WRITTEN'")
     Page<CommentDto> findCommentDtoPage(Pageable pageable);

--- a/src/main/java/project/mbti/comment/dto/CommentDto.java
+++ b/src/main/java/project/mbti/comment/dto/CommentDto.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import project.mbti.MBTI;
+import project.mbti.comment.entity.CommentState;
 
 import java.time.LocalDateTime;
 
@@ -21,9 +22,6 @@ public class CommentDto {
 
     @ApiModelProperty(value = "댓글 PK", example = "1")
     private Long id;
-
-    @ApiModelProperty(value = "부모 댓글 FK", example = "1",  notes = "댓글인 경우, PK와 동일")
-    private Long parentId;
 
     @ApiModelProperty(value = "댓글 생성 일자", example = "2021-10-30 08:31:01")
     private LocalDateTime createdDate;
@@ -42,4 +40,7 @@ public class CommentDto {
 
     @ApiModelProperty(value = "대댓글 개수", example = "5")
     private int childSize;
+
+    @ApiModelProperty(value = "댓글 상태", example = "WRITTEN")
+    private CommentState state;
 }

--- a/src/main/java/project/mbti/comment/entity/Comment.java
+++ b/src/main/java/project/mbti/comment/entity/Comment.java
@@ -66,11 +66,12 @@ public class Comment {
     public CommentDto convert() {
         return CommentDto.builder()
                 .id(getId())
-                .parentId(getParent().getId())
                 .createdDate(getCreatedDate())
+                .mbti(getMbti())
                 .name(getName())
                 .password(getPassword())
                 .content(getContent())
+                .state(getState())
                 .build();
     }
 


### PR DESCRIPTION
### 변경 사항
- 댓글 삭제 로직 변경으로 인한, HTTP Method 변경
   - 댓글 엔티티 삭제 -> 댓글 상태 `DELETED`로 변경
   - 따라서, `PATCH` method로 변경
- 댓글 페이징 조회 API 응답 데이터 수정
   - parentId 제거
   - state 추가

Resolve: #38 