### PR TITLE
Test: 댓글 API 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2:1.4.200'
 }
 
 test {

--- a/src/main/java/project/mbti/response/error/ErrorResponse.java
+++ b/src/main/java/project/mbti/response/error/ErrorResponse.java
@@ -1,6 +1,8 @@
 package project.mbti.response.error;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
@@ -9,6 +11,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
 
     private int status;
@@ -49,6 +52,7 @@ public class ErrorResponse {
     }
 
     @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class FieldError {
         private String field;
         private String value;

--- a/src/main/java/project/mbti/response/result/ResultResponse.java
+++ b/src/main/java/project/mbti/response/result/ResultResponse.java
@@ -2,10 +2,13 @@ package project.mbti.response.result;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @ApiModel(description = "결과 응답 데이터 모델")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ResultResponse {
 
     @ApiModelProperty(value = "Http 상태 코드")

--- a/src/test/java/project/mbti/comment/CommentControllerTest.java
+++ b/src/test/java/project/mbti/comment/CommentControllerTest.java
@@ -1,59 +1,332 @@
 package project.mbti.comment;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.filter.CharacterEncodingFilter;
-import project.mbti.comment.dto.CommentWriteDto;
+import org.springframework.test.web.servlet.ResultActions;
 import project.mbti.MBTI;
+import project.mbti.comment.dto.CommentDeleteDto;
+import project.mbti.comment.dto.CommentDto;
+import project.mbti.comment.dto.CommentWriteDto;
+import project.mbti.comment.entity.Comment;
+import project.mbti.comment.entity.CommentState;
+import project.mbti.exception.CommentNameNotMatchException;
+import project.mbti.exception.CommentNotFoundException;
+import project.mbti.exception.CommentPasswordNotMatchException;
+import project.mbti.exception.InvalidMbtiException;
 
-import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Transactional
-@DisplayName("댓글_API_테스트")
-@SpringBootTest
+/**
+ * @WebMvcTest 어노테이션을 사용하면 웹 레이어 테스트를 하는 데 필요한
+ * @Controller, @ControllerAdvice, @JsonComponent, Converter, GenericConverter,
+ * Filter, WebMvcConfigurer, HandlerMethodArgumentResolver 등만 Bean으로 등록한다.
+ * <p>
+ * 이 밖에 테스트를 하는 데 필요하지 않은 컴포넌트들(ex. @Service, @Repository)은 Bean으로 등록하지 않는다.
+ */
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(CommentController.class)
 class CommentControllerTest {
 
     @Autowired
-    CommentController commentController;
+    private MockMvc mockMvc;
 
-    MockMvc mockMvc;
+    @MockBean
+    private CommentService commentService;
 
-    @Autowired
-    ObjectMapper objectMapper;
-
-    @BeforeEach
-    void setup() {
-        mockMvc = MockMvcBuilders.standaloneSetup(commentController)
-                .addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
-                .alwaysDo(print())
+    @Test
+    @DisplayName("댓글 작성 API")
+    void write_api() throws Exception {
+        // given
+        Comment comment = Comment.builder()
+                .name("만두")
+                .password("1234")
+                .mbti(MBTI.ISTJ)
+                .content("댓글")
+                .parent(Optional.empty())
                 .build();
+
+        CommentWriteDto commentWriteDto = new CommentWriteDto(MBTI.ISTJ, "만두", "1234", "댓글");
+
+        doReturn(comment).when(commentService).create(comment.getMbti(), comment.getName(), comment.getPassword(), comment.getContent(), 0L);
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                post("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(commentWriteDto)));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("code").value("C100"));
     }
 
     @Test
-    @DisplayName("댓글_작성")
-    void write() throws Exception {
+    @DisplayName("댓글 작성 API 예외1: 유효하지 않은 MBTI 입력")
+    void write_api_ex1() throws Exception {
         // given
-        String commentWriteDto = objectMapper.writeValueAsString(new CommentWriteDto(MBTI.ISTJ, "만두", "1234", "우와 신기해요!"));
+        Comment comment = Comment.builder()
+                .name("만두")
+                .password("1234")
+                .mbti(MBTI.NOT_FOUND)
+                .content("댓글")
+                .parent(Optional.empty())
+                .build();
+
+        CommentWriteDto commentWriteDto = new CommentWriteDto(MBTI.NOT_FOUND, "만두", "1234", "댓글");
+
+        doThrow(new InvalidMbtiException()).when(commentService).create(comment.getMbti(), comment.getName(), comment.getPassword(), comment.getContent(), 0L);
 
         // when
-        mockMvc.perform(post("/comment")
-                .contentType(APPLICATION_JSON)
-                .content(commentWriteDto))
+        final ResultActions perform = mockMvc.perform(
+                post("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(commentWriteDto)));
 
         // then
-                .andExpect(status().is2xxSuccessful())
-                .andDo(print());
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("M001"));
+    }
+
+    @Test
+    @DisplayName("댓글 작성 API 예외2: BindException")
+    void write_api_ex2() throws Exception {
+        // given
+        CommentWriteDto commentWriteDto = new CommentWriteDto(null, "만두", "1234", "댓글");
+        CommentWriteDto commentWriteDto2 = new CommentWriteDto(MBTI.ISTJ, "만", "1234", "댓글");
+        CommentWriteDto commentWriteDto3 = new CommentWriteDto(MBTI.ISTJ, "만두", "1", "댓글");
+        CommentWriteDto commentWriteDto4 = new CommentWriteDto(MBTI.ISTJ, "만두", "1234", " ");
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                post("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(commentWriteDto)));
+        final ResultActions perform2 = mockMvc.perform(
+                post("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(commentWriteDto2)));
+        final ResultActions perform3 = mockMvc.perform(
+                post("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(commentWriteDto3)));
+        final ResultActions perform4 = mockMvc.perform(
+                post("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(commentWriteDto4)));
+
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("U002"));
+        perform2
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("U002"));
+        perform3
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("U002"));
+        perform4
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("U002"));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 API")
+    void delete_api() throws Exception {
+        // given
+        Comment comment = Comment.builder()
+                .name("만두")
+                .password("1234")
+                .mbti(MBTI.ISTJ)
+                .content("댓글")
+                .parent(Optional.empty())
+                .build();
+        comment.updateState(CommentState.DELETED);
+
+        CommentDeleteDto dto = new CommentDeleteDto(1L, "만두", "1234");
+
+        doReturn(comment).when(commentService).delete(any(Long.class), any(String.class), any(String.class));
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                patch("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(dto)));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("code").value("C101"));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 API 예외1: 존재하지 않는 댓글")
+    void delete_api_ex1() throws Exception {
+        // given
+        CommentDeleteDto dto = new CommentDeleteDto(1L, "만두", "1234");
+
+        doThrow(new CommentNotFoundException()).when(commentService).delete(any(Long.class), any(String.class), any(String.class));
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                patch("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(dto)));
+
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("C001"));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 API 예외2: 댓글 작성자 닉네임 불일치")
+    void delete_api_ex2() throws Exception {
+        // given
+        CommentDeleteDto dto = new CommentDeleteDto(1L, "구름", "1234");
+
+        doThrow(new CommentNameNotMatchException()).when(commentService).delete(any(Long.class), any(String.class), any(String.class));
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                patch("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(dto)));
+
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("C002"));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 API 예외3: 댓글 작성자 비밀번호 불일치")
+    void delete_api_ex3() throws Exception {
+        // given
+        CommentDeleteDto dto = new CommentDeleteDto(1L, "만두", "4321");
+
+        doThrow(new CommentPasswordNotMatchException()).when(commentService).delete(any(Long.class), any(String.class), any(String.class));
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                patch("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(dto)));
+
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("C003"));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 API 예외4: BindException")
+    void delete_api_ex4() throws Exception {
+        // given
+        CommentDeleteDto CommentDeleteDto = new CommentDeleteDto(1L, "만", "1234");
+        CommentDeleteDto CommentDeleteDto2 = new CommentDeleteDto(1L, "만두", " ");
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                patch("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(CommentDeleteDto)));
+        final ResultActions perform2 = mockMvc.perform(
+                patch("/comment")
+                        .contentType(APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(CommentDeleteDto2)));
+
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("U002"));
+        perform2
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("U002"));
+    }
+
+    @Test
+    @DisplayName("댓글 페이징 조회 API")
+    void commentList() throws Exception {
+        // given
+        int page = 1, size = 10;
+        List<CommentDto> commentDtos = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            Comment comment = Comment.builder()
+                    .name("만두" + i)
+                    .password("1234")
+                    .mbti(MBTI.ISTJ)
+                    .content("안녕" + i)
+                    .parent(java.util.Optional.empty())
+                    .build();
+            ReflectionTestUtils.setField(comment, "id", (long) i);
+
+            commentDtos.add(comment.convert());
+        }
+
+        final Page<CommentDto> commentDtoPage = new PageImpl<>(commentDtos);
+
+        doReturn(commentDtoPage).when(commentService).getCommentPage(page, size);
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                get("/comment")
+                        .contentType(APPLICATION_FORM_URLENCODED_VALUE)
+                        .param("page", Integer.toString(page))
+                        .param("size", Integer.toString(size)));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("code").value("C102"));
+    }
+
+    @Test
+    @DisplayName("댓글 페이징 조회 API 예외1: ArgsTypeMissMatch Exception")
+    void commentList_ex1() throws Exception {
+        // given
+        String validArg = "1";
+        String invalidArg = "asdf";
+
+        // when
+        final ResultActions perform = mockMvc.perform(
+                get("/comment")
+                        .contentType(APPLICATION_FORM_URLENCODED_VALUE)
+                        .param("page", invalidArg)
+                        .param("size", validArg));
+        final ResultActions perform2 = mockMvc.perform(
+                get("/comment")
+                        .contentType(APPLICATION_FORM_URLENCODED_VALUE)
+                        .param("page", validArg)
+                        .param("size", invalidArg));
+
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("U004"));
+        perform2
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("U004"));
+
     }
 }

--- a/src/test/java/project/mbti/comment/CommentIntegrationTest.java
+++ b/src/test/java/project/mbti/comment/CommentIntegrationTest.java
@@ -1,0 +1,170 @@
+package project.mbti.comment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.transaction.annotation.Transactional;
+import project.mbti.MBTI;
+import project.mbti.comment.dto.CommentDeleteDto;
+import project.mbti.comment.dto.CommentDto;
+import project.mbti.comment.dto.CommentWriteDto;
+import project.mbti.comment.entity.CommentState;
+import project.mbti.response.error.ErrorResponse;
+import project.mbti.response.result.ResultResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+public class CommentIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    final String url = "/comment";
+
+    /**
+     * {@code ObjectMapper.convertValue()}
+     * @Reference https://stackoverflow.com/questions/15430715/casting-linkedhashmap-to-complex-object
+     */
+    @Test
+    @DisplayName("댓글 작성 API")
+    void write_api() throws Exception {
+        // given
+        final CommentWriteDto dto = new CommentWriteDto(MBTI.ISTJ, "만두", "1234", "댓글");
+        final HttpEntity<CommentWriteDto> request = new HttpEntity<>(dto);
+
+        // when
+        ResponseEntity<ResultResponse> response = restTemplate.postForEntity(url, request, ResultResponse.class);
+        final CommentDto commentDto = objectMapper.convertValue(response.getBody().getData(), CommentDto.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getCode()).isEqualTo("C100");
+        assertThat(commentDto.getId()).isEqualTo(1L);
+        assertThat(commentDto.getName()).isEqualTo(dto.getName());
+        assertThat(commentDto.getPassword()).isEqualTo(dto.getPassword());
+        assertThat(commentDto.getContent()).isEqualTo(dto.getContent());
+        assertThat(commentDto.getMbti()).isEqualTo(dto.getMbti());
+        assertThat(commentDto.getChildSize()).isEqualTo(0);
+        assertThat(commentDto.getCreatedDate()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("댓글 작성 API 예외1: 유효하지 않은 MBTI 입력")
+    void write_api_ex1() throws Exception {
+        // given
+        final CommentWriteDto dto = new CommentWriteDto(MBTI.NOT_FOUND, "만두", "1234", "댓글");
+        final HttpEntity<CommentWriteDto> request = new HttpEntity<>(dto);
+
+        // when
+        ResponseEntity<ErrorResponse> response = restTemplate.postForEntity(url, request, ErrorResponse.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo("M001");
+    }
+
+    @Test
+    @DisplayName("댓글 작성 API 예외2: BindException")
+    void write_api_ex2() throws Exception {
+        // given
+        final CommentWriteDto dto = new CommentWriteDto(MBTI.ISTJ, "만", "", "  ");
+        final HttpEntity<CommentWriteDto> request = new HttpEntity<>(dto);
+
+        // when
+        ResponseEntity<ErrorResponse> response = restTemplate.postForEntity(url, request, ErrorResponse.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo("U002");
+        assertThat(response.getBody().getErrors().size()).isEqualTo(4);
+    }
+
+    void init() {
+        final CommentWriteDto dto = new CommentWriteDto(MBTI.ISTJ, "만두", "1234", "댓글");
+        final HttpEntity<CommentWriteDto> request = new HttpEntity<>(dto);
+        restTemplate.postForEntity(url, request, ResultResponse.class);
+    }
+
+    /**
+     * {@code RestTemplate PATCH 지원X 해결 방법}
+     * @Reference https://blog.voidmainvoid.net/224
+     */
+    @Test
+    @DisplayName("댓글 삭제 API")
+    void delete_api() throws Exception {
+        // given
+        init();
+        final CommentDeleteDto dto = new CommentDeleteDto(1L, "만두", "1234");
+        final HttpEntity<CommentDeleteDto> request = new HttpEntity<>(dto);
+
+        // when
+        final ResponseEntity<ResultResponse> response = restTemplate.exchange(url, HttpMethod.PATCH, request, ResultResponse.class);
+        final CommentDto commentDto = objectMapper.convertValue(response.getBody().getData(), CommentDto.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getCode()).isEqualTo("C101");
+        assertThat(commentDto.getState()).isEqualTo(CommentState.DELETED);
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 API 예외1: 존재하지 않는 댓글 삭제")
+    void delete_api_ex1() throws Exception {
+        // given
+        final CommentDeleteDto dto = new CommentDeleteDto(3L, "만두", "1234");
+        final HttpEntity<CommentDeleteDto> request = new HttpEntity<>(dto);
+
+        // when
+        final ResponseEntity<ErrorResponse> response = restTemplate.exchange(url, HttpMethod.PATCH, request, ErrorResponse.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo("C001");
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 API 예외2: 댓글 작성자 정보 불일치")
+    void delete_api_ex2() throws Exception {
+        // given
+        init();
+        final CommentDeleteDto dto = new CommentDeleteDto(1L, "구름", "1234");
+        final HttpEntity<CommentDeleteDto> request = new HttpEntity<>(dto);
+        final CommentDeleteDto dto2 = new CommentDeleteDto(1L, "만두", "4321");
+        final HttpEntity<CommentDeleteDto> request2 = new HttpEntity<>(dto2);
+
+        // when
+        final ResponseEntity<ErrorResponse> response = restTemplate.exchange(url, HttpMethod.PATCH, request, ErrorResponse.class);
+        final ResponseEntity<ErrorResponse> response2 = restTemplate.exchange(url, HttpMethod.PATCH, request2, ErrorResponse.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo("C002");
+        assertThat(response2.getBody().getCode()).isEqualTo("C003");
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 API 예외3: BindException")
+    void delete_api_ex3() throws Exception {
+        // given
+        final CommentDeleteDto dto = new CommentDeleteDto(null, " ", " ");
+        final HttpEntity<CommentDeleteDto> request = new HttpEntity<>(dto);
+
+        // when
+        final ResponseEntity<ErrorResponse> response = restTemplate.exchange(url, HttpMethod.PATCH, request, ErrorResponse.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo("U002");
+        assertThat(response.getBody().getErrors().size()).isEqualTo(5);
+    }
+}

--- a/src/test/java/project/mbti/comment/CommentRepositoryTest.java
+++ b/src/test/java/project/mbti/comment/CommentRepositoryTest.java
@@ -1,0 +1,73 @@
+package project.mbti.comment;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import project.mbti.MBTI;
+import project.mbti.comment.dto.CommentDto;
+import project.mbti.comment.entity.Comment;
+import project.mbti.comment.entity.CommentState;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @DataJpaTest
+ * JPA 관련된 설정만 로드한다. (WebMVC와 관련된 Bean이나 기능은 로드되지 않는다)
+ * JPA를 사용해서 생성/조회/수정/삭제 기능의 테스트가 가능하다.
+ * @Transactional 을 기본적으로 내장하고 있으므로, 매 테스트 코드가 종료되면 자동으로 DB가 롤백된다.
+ * 기본적으로 내장 DB를 사용하는데, 설정을 통해 실제 DB로 테스트도 가능하다. (권장하지 않는다)
+ * @Entity 가 선언된 클래스를 스캔하여 저장소를 구성한다.
+ */
+@DataJpaTest
+class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @BeforeEach
+    private void init() {
+        for (int i = 0; i < 5; i++) {
+            Comment comment = Comment.builder()
+                    .name("만두" + i)
+                    .password("1234")
+                    .mbti(MBTI.ISTJ)
+                    .content("안녕" + i)
+                    .parent(java.util.Optional.empty())
+                    .build();
+
+            commentRepository.save(comment);
+        }
+
+        for (int i = 5; i < 10; i++) {
+            Comment comment = Comment.builder()
+                    .name("만두" + i)
+                    .password("1234")
+                    .mbti(MBTI.ISTJ)
+                    .content("안녕" + i)
+                    .parent(java.util.Optional.empty())
+                    .build();
+
+            commentRepository.save(comment);
+            comment.updateState(CommentState.DELETED);
+        }
+    }
+
+    @Test
+    @DisplayName("댓글 페이징 조회: WRITTEN만 조회 성공")
+    void findCommentDtoPage() throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(1, 10);
+
+        // when
+        final Page<CommentDto> commentDtoPage = commentRepository.findCommentDtoPage(pageable);
+
+        // then
+        assertThat(commentDtoPage.getTotalElements()).isEqualTo(5);
+    }
+}

--- a/src/test/java/project/mbti/comment/CommentServiceTest.java
+++ b/src/test/java/project/mbti/comment/CommentServiceTest.java
@@ -2,126 +2,213 @@ package project.mbti.comment;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+import org.springframework.test.util.ReflectionTestUtils;
+import project.mbti.MBTI;
 import project.mbti.comment.dto.CommentDto;
 import project.mbti.comment.entity.Comment;
-import project.mbti.MBTI;
+import project.mbti.comment.entity.CommentState;
 import project.mbti.exception.CommentNameNotMatchException;
 import project.mbti.exception.CommentNotFoundException;
 import project.mbti.exception.CommentPasswordNotMatchException;
+import project.mbti.exception.InvalidMbtiException;
+import project.mbti.report.ReportRepository;
+import project.mbti.util.BadWordsFilter;
 
-
+import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
-@Transactional
-@DisplayName("댓글_로직_테스트")
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
 
-    @Autowired
-    CommentService commentService;
-    @Autowired
-    CommentRepository commentRepository;
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private EntityManager em;
+
+    @Mock
+    BadWordsFilter badWordsFilter;
+
+    @InjectMocks
+    private CommentService commentService;
 
     @Test
-    @DisplayName("댓글_작성")
-    void write_comment() throws Exception {
+    @DisplayName("댓글 생성: 비속어 필터링")
+    void create() throws Exception {
         // given
-        final MBTI mbti = MBTI.ISTJ;
-        final String name = "만두";
-        final String password = "1234";
-        final String content = "우와 신기해요!";
+        Comment comment = Comment.builder()
+                .name("만두")
+                .password("1234")
+                .mbti(MBTI.ISTJ)
+                .content("shit!!")
+                .parent(Optional.empty())
+                .build();
+        ReflectionTestUtils.setField(comment, "id", 1L);
+
+        Comment filteredComment = Comment.builder()
+                .name("만두")
+                .password("1234")
+                .mbti(MBTI.ISTJ)
+                .content("****!!")
+                .parent(Optional.empty())
+                .build();
+        ReflectionTestUtils.setField(filteredComment, "id", 1L);
+
+        doReturn("****!!").when(badWordsFilter).filterText("shit!!");
+        doReturn(filteredComment).when(commentRepository).save(any(Comment.class));
 
         // when
-        final Comment comment = commentService.create(mbti, name, password, content, null);
+        final Comment savedComment = commentService.create(comment.getMbti(), comment.getName(), comment.getPassword(), comment.getContent(), 0L);
 
         // then
-        assertThat(commentService.findById(comment.getId()).get().getContent()).isEqualTo(content);
+        verify(commentRepository, times(1)).save(any(Comment.class));
+        assertThat(comment.getId()).isEqualTo(savedComment.getId());
+        assertThat(comment.getName()).isEqualTo(savedComment.getName());
+        assertThat(comment.getPassword()).isEqualTo(savedComment.getPassword());
+        assertThat(comment.getContent()).isNotEqualTo(savedComment.getContent());
     }
 
-    @Test
-    @DisplayName("댓글_작성_비속어_필터링")
-    void write_comment_filtering() throws Exception {
-        // given
-        final MBTI mbti = MBTI.ISTJ;
-        final String name = "만두";
-        final String password = "1234";
-        final String content = "fuck!!! 개자식아";
+   @Test
+   @DisplayName("댓글 생성 예외1: 유효하지 않은 MBTI 입력")
+   void create_ex1() throws Exception {
+       // given
+       final Comment comment = Comment.builder()
+               .name("만두")
+               .password("1234")
+               .mbti(MBTI.NOT_FOUND)
+               .content("댓글!")
+               .parent(Optional.empty())
+               .build();
 
-        // when
-        final Comment comment = commentService.create(mbti, name, password, content, null);
+       // when
+       final Executable create = () -> commentService.create(comment.getMbti(), comment.getName(), comment.getPassword(), comment.getContent(), 0L);
 
-        // then
-        assertThat(commentService.findById(comment.getId()).get().getContent()).isEqualTo("****!!! ***아");
-    }
+       // then
+       assertThrows(InvalidMbtiException.class, create);
+   }
 
-    @Test
-    @DisplayName("댓글_삭제")
-    void delete_comment() throws Exception {
-        // given
-        final MBTI mbti = MBTI.ISTJ;
-        final String name = "만";
-        final String password = "1234";
-        final String content = "우와 신기해요!";
-        final Comment comment = commentService.create(mbti, name, password, content, null);
+   @Test
+   @DisplayName("댓글 삭제")
+   void delete() throws Exception {
+       // given
+       Comment comment = Comment.builder()
+               .name("만두")
+               .password("1234")
+               .mbti(MBTI.ISTJ)
+               .content("댓글!")
+               .parent(Optional.empty())
+               .build();
+       ReflectionTestUtils.setField(comment, "id", 1L);
 
-        // when
-        commentService.delete(comment.getId(), comment.getName(), comment.getPassword());
+       doNothing().when(reportRepository).bulkUpdateReportStateByCommentId(any(Long.class));
+       doNothing().when(em).flush();
+       doReturn(Optional.of(comment)).when(commentRepository).findById(any(Long.class));
 
-        // then
-        assertThat(commentService.findById(1L)).isEqualTo(Optional.empty());
-    }
+       // when
+       commentService.delete(comment.getId(), comment.getName(), comment.getPassword());
 
-    @Test
-    @DisplayName("댓글_삭제_예외")
-    void delete_comment_exception() throws Exception {
-        // given
-        final MBTI mbti = MBTI.ISTJ;
-        final String name = "만두";
-        final String password = "1234";
-        final String content = "우와 신기해요!";
-        final Comment comment = commentService.create(mbti, name, password, content, null);
+       // then
+       assertThat(comment.getState()).isEqualTo(CommentState.DELETED);
+   }
 
-        // when
-        Long wrongId = 2L;
-        String wrongName = "찐빵";
-        String wrongPassword = "4321";
+   @Test
+   @DisplayName("댓글 삭제 예외1: 존재하지 않는 댓글")
+   void delete_ex1() throws Exception {
+       // given
+       doThrow(new CommentNotFoundException()).when(commentRepository).findById(any(Long.class));
 
-        // then
-        assertThrows(CommentNotFoundException.class, () -> {
-            commentService.delete(wrongId, comment.getName(), comment.getPassword());
-        });
-        assertThrows(CommentNameNotMatchException.class, () -> {
-            commentService.delete(comment.getId(), wrongName, comment.getPassword());
-        });
-        assertThrows(CommentPasswordNotMatchException.class, () -> {
-            commentService.delete(comment.getId(), comment.getName(), wrongPassword);
-        });
-    }
+       // when
+       final Executable delete = () -> commentService.delete(1L, "만두", "1234");
 
-    @Test
-    @DisplayName("댓글_페이징")
-    void paging_comment() throws Exception {
-        // given
-        final MBTI mbti = MBTI.ISTJ;
-        final String name = "만";
-        final String password = "1234";
-        final String content = "우와 신기해요!";
-        final Comment comment = commentService.create(mbti, name, password, content, null);
-        final Comment comment2 = commentService.create(mbti, name, password, content, null);
-        final Comment comment3 = commentService.create(mbti, name, password, content, null);
+       // then
+       assertThrows(CommentNotFoundException.class, delete);
+   }
 
-        // when
-        final Page<CommentDto> commentPage = commentService.getCommentPage(0, 5);
+   @Test
+   @DisplayName("댓글 삭제 예외2: 작성자 이름 불일치")
+   void delete_ex2() throws Exception {
+       // given
+       Comment comment = Comment.builder()
+               .name("만두")
+               .password("1234")
+               .mbti(MBTI.ISTJ)
+               .content("댓글!")
+               .parent(Optional.empty())
+               .build();
 
-        // then
-        assertThat(commentPage.getTotalElements()).isEqualTo(3);
-        assertThat(commentPage.getContent().get(0).getId()).isEqualTo(comment3.getId());
-    }
+       doReturn(Optional.of(comment)).when(commentRepository).findById(any(Long.class));
+
+       // when
+       final Executable delete = () -> commentService.delete(1L, "구름", "1234");
+
+       // then
+       assertThrows(CommentNameNotMatchException.class, delete);
+   }
+
+   @Test
+   @DisplayName("댓글 삭제 예외3: 작성자 비밀번호 불일치")
+   void delete_ex3() throws Exception {
+       // given
+       Comment comment = Comment.builder()
+               .name("만두")
+               .password("1234")
+               .mbti(MBTI.ISTJ)
+               .content("댓글!")
+               .parent(Optional.empty())
+               .build();
+
+       doReturn(Optional.of(comment)).when(commentRepository).findById(any(Long.class));
+
+       // when
+       final Executable delete = () -> commentService.delete(1L, "만두", "4321");
+
+       // then
+       assertThrows(CommentPasswordNotMatchException.class, delete);
+   }
+
+   @Test
+   @DisplayName("댓글 페이징 조회")
+   void getCommentPage() throws Exception {
+       // given
+       List<CommentDto> commentDtos = new ArrayList<>();
+       for (int i = 0; i < 5; i++) {
+           Comment comment = Comment.builder()
+                   .name("만두" + i)
+                   .password("1234")
+                   .mbti(MBTI.ISTJ)
+                   .content("안녕" + i)
+                   .parent(java.util.Optional.empty())
+                   .build();
+           ReflectionTestUtils.setField(comment, "id", (long) i);
+
+           commentDtos.add(comment.convert());
+       }
+
+       final Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "id"));
+       final Page<CommentDto> page = new PageImpl<>(commentDtos);
+
+       doReturn(page).when(commentRepository).findCommentDtoPage(pageable);
+
+       // when
+       final Page<CommentDto> commentPage = commentService.getCommentPage(1, 10);
+
+       // then
+       assertThat(commentPage.getTotalElements()).isEqualTo(5);
+   }
 }


### PR DESCRIPTION
### 변경 사항
- 단위 테스트
   - CommentController, CommentService, CommentRepository
   - Mockito 라이브러리 이용
- 통합 테스트
   - 댓글 작성 API, 댓글 삭제 API
   - 댓글 페이징 조회 API는 지속적인 파라미터 컨버팅 오류 발생 -> 보류
- 이전 테스트 코드 제거
- 내장 메모리 DB 이용하기 위해, H2 Database 의존성 추가
- RestTemplate는 PATCH를 지원하지 않아서, HttpComponents:HttpClient 의존성 추가
- ResultResponse, ErrorResponse -> 테스팅 환경에서 컨버팅 위해서 기본 생성자 추가

Resolve: #37 