### PR TITLE
차단 API 추가 + 댓글API, 신고API에 차단 로직 추가

### DIFF
--- a/src/main/java/project/mbti/block/BlockController.java
+++ b/src/main/java/project/mbti/block/BlockController.java
@@ -1,0 +1,59 @@
+package project.mbti.block;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import project.mbti.block.dto.BlockIpDto;
+import project.mbti.block.entity.Block;
+import project.mbti.response.result.ResultResponse;
+
+import javax.validation.constraints.NotNull;
+
+import static project.mbti.response.result.ResultCode.*;
+
+@Api(tags = "차단 API")
+@RestController
+@RequiredArgsConstructor
+public class BlockController {
+
+    private final BlockService blockService;
+
+    @ApiOperation(value = "IP 차단", notes = "IP 차단 시, 댓글&신고 작성이 불가능 합니다.")
+    @PostMapping("/block")
+    public ResponseEntity<ResultResponse> block(@Validated @RequestBody BlockIpDto dto) {
+        final Block block = blockService.create(dto.getIp());
+
+        return ResponseEntity.ok()
+                .body(ResultResponse.of(BLOCK_IP_SUCCESS, block));
+    }
+
+    @ApiOperation("IP 차단 목록 페이징 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "차단 명단 수", example = "5", required = true)
+    })
+    @GetMapping("/block")
+    public ResponseEntity<ResultResponse> blockList(
+            @Validated @NotNull(message = "페이지를 입력해주세요.") @RequestParam int page,
+            @Validated @NotNull(message = "차단 명단 수를 입력해주세요.") @RequestParam int size) {
+        final Page<Block> blocks = blockService.getBlockPage(page, size);
+
+        return ResponseEntity.ok()
+                .body(ResultResponse.of(FIND_BLOCK_PAGE_SUCCESS, blocks));
+    }
+
+    @ApiOperation("IP 차단 해제")
+    @DeleteMapping("/block")
+    public ResponseEntity<ResultResponse> unblock(@Validated @RequestBody BlockIpDto dto) {
+        blockService.delete(dto.getIp());
+
+        return ResponseEntity.ok()
+                .body(ResultResponse.of(UNBLOCK_IP_SUCCESS, null));
+    }
+}

--- a/src/main/java/project/mbti/block/BlockRepository.java
+++ b/src/main/java/project/mbti/block/BlockRepository.java
@@ -1,0 +1,10 @@
+package project.mbti.block;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.mbti.block.entity.Block;
+
+import java.util.Optional;
+
+public interface BlockRepository extends JpaRepository<Block, Long> {
+    Optional<Block> findByIp(String ip);
+}

--- a/src/main/java/project/mbti/block/BlockService.java
+++ b/src/main/java/project/mbti/block/BlockService.java
@@ -1,0 +1,42 @@
+package project.mbti.block;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.mbti.block.entity.Block;
+import project.mbti.exception.AlreadyBlockedIpException;
+import project.mbti.exception.IpNotFoundException;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BlockService {
+
+    private final BlockRepository blockRepository;
+
+    @Transactional
+    public Block create(String ip) {
+        if (blockRepository.findByIp(ip).isPresent())
+            throw new AlreadyBlockedIpException();
+
+        return blockRepository.save(new Block(ip));
+    }
+
+    public Page<Block> getBlockPage(int page, int size) {
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(DESC, "id"));
+        return blockRepository.findAll(pageable);
+    }
+
+    @Transactional
+    public void delete(String ip) {
+        final Block block = blockRepository.findByIp(ip).orElseThrow(IpNotFoundException::new);
+        blockRepository.delete(block);
+    }
+}

--- a/src/main/java/project/mbti/block/dto/BlockIpDto.java
+++ b/src/main/java/project/mbti/block/dto/BlockIpDto.java
@@ -1,0 +1,21 @@
+package project.mbti.block.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@ApiModel(description = "IP 차단 요청 데이터 모델")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlockIpDto {
+
+    @ApiModelProperty(value = "작성자 IP", example = "111.111.111.111,11.111.11.111", required = true)
+    @NotBlank(message = "IP는 필수입니다.")
+    private String ip;
+}

--- a/src/main/java/project/mbti/block/entity/Block.java
+++ b/src/main/java/project/mbti/block/entity/Block.java
@@ -1,0 +1,33 @@
+package project.mbti.block.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "blocks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Block {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "block_id")
+    private Long id;
+
+    private String ip;
+
+    @CreatedDate
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    public Block(String ip) {
+        this.ip = ip;
+    }
+}

--- a/src/main/java/project/mbti/comment/CommentController.java
+++ b/src/main/java/project/mbti/comment/CommentController.java
@@ -10,9 +10,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import project.mbti.comment.dto.*;
+import project.mbti.response.result.ResultCode;
 import project.mbti.response.result.ResultResponse;
 import project.mbti.comment.entity.Comment;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 
 import static project.mbti.response.result.ResultCode.*;
@@ -26,22 +28,26 @@ public class CommentController {
 
     @ApiOperation(value = "댓글 작성")
     @PostMapping("/comment")
-    public ResponseEntity<ResultResponse> write(@Validated @RequestBody CommentWriteDto dto) {
-        final Comment comment = commentService.create(dto.getMbti(), dto.getName(), dto.getPassword(), dto.getContent(), 0L);
-        final CommentDto commentDto = comment.convert();
+    public ResponseEntity<ResultResponse> write(@Validated @RequestBody CommentWriteDto dto, HttpServletRequest request) {
+        final String clientIp = request.getHeader("X-Forwarded-For");
+        final CommentWriteResultType result = commentService.create(dto.getMbti(), dto.getName(), dto.getPassword(), dto.getContent(), 0L, clientIp);
+        final CommentWriteResponseDto commentWriteResponseDto = new CommentWriteResponseDto(result, clientIp);
+        final ResultCode resultCode = result.equals(CommentWriteResultType.SUCCESS) ? WRITE_COMMENT_SUCCESS : WRITE_COMMENT_FAILURE;
 
         return ResponseEntity.ok()
-                .body(ResultResponse.of(WRITE_COMMENT_SUCCESS, commentDto));
+                .body(ResultResponse.of(resultCode, commentWriteResponseDto));
     }
 
     @ApiOperation(value = "대댓글 작성")
     @PostMapping("/reply")
-    public ResponseEntity<ResultResponse> reply(@Validated @RequestBody ReplyWriteDto dto) {
-        final Comment comment = commentService.create(dto.getMbti(), dto.getName(), dto.getPassword(), dto.getContent(), dto.getParentId());
-        final CommentDto commentDto = comment.convert();
+    public ResponseEntity<ResultResponse> reply(@Validated @RequestBody ReplyWriteDto dto, HttpServletRequest request) {
+        final String clientIp = request.getHeader("X-Forwarded-For");
+        final CommentWriteResultType result = commentService.create(dto.getMbti(), dto.getName(), dto.getPassword(), dto.getContent(), dto.getParentId(), clientIp);
+        final CommentWriteResponseDto commentWriteResponseDto = new CommentWriteResponseDto(result, clientIp);
+        final ResultCode resultCode = result.equals(CommentWriteResultType.SUCCESS) ? WRITE_COMMENT_SUCCESS : WRITE_COMMENT_FAILURE;
 
         return ResponseEntity.ok()
-                .body(ResultResponse.of(WRITE_COMMENT_SUCCESS, commentDto));
+                .body(ResultResponse.of(resultCode, commentWriteResponseDto));
     }
 
     @ApiOperation(value = "댓글 삭제")

--- a/src/main/java/project/mbti/comment/dto/CommentWriteResponseDto.java
+++ b/src/main/java/project/mbti/comment/dto/CommentWriteResponseDto.java
@@ -1,0 +1,21 @@
+package project.mbti.comment.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@ApiModel(description = "댓글 작성 결과 응답 데이터 모델")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentWriteResponseDto {
+
+    @ApiModelProperty(value = "댓글 작성 결과", example = "SUCCESS")
+    private CommentWriteResultType result;
+
+    @ApiModelProperty(value = "댓글 작성자 IP", example = "111.111.111.111,11.111.11.111")
+    private String clientIp;
+}

--- a/src/main/java/project/mbti/comment/dto/CommentWriteResultType.java
+++ b/src/main/java/project/mbti/comment/dto/CommentWriteResultType.java
@@ -1,0 +1,5 @@
+package project.mbti.comment.dto;
+
+public enum CommentWriteResultType {
+    SUCCESS, BLOCKED_IP
+}

--- a/src/main/java/project/mbti/comment/entity/Comment.java
+++ b/src/main/java/project/mbti/comment/entity/Comment.java
@@ -52,14 +52,16 @@ public class Comment {
     private String name;
     private String password;
     private String content;
+    private String ip;
 
     @Builder
-    public Comment(Optional<Comment> parent, MBTI mbti, String name, String password, String content) {
+    public Comment(Optional<Comment> parent, MBTI mbti, String name, String password, String content, String ip) {
         this.parent = (parent.isEmpty() ? this : parent.get());
         this.mbti = mbti;
         this.name = name;
         this.password = password;
         this.content = content;
+        this.ip = ip;
         this.state = WRITTEN;
     }
 

--- a/src/main/java/project/mbti/exception/AlreadyBlockedIpException.java
+++ b/src/main/java/project/mbti/exception/AlreadyBlockedIpException.java
@@ -1,0 +1,10 @@
+package project.mbti.exception;
+
+import project.mbti.response.error.ErrorCode;
+
+public class AlreadyBlockedIpException extends BusinessException {
+
+    public AlreadyBlockedIpException() {
+        super(ErrorCode.ALREADY_BLOCKED_IP);
+    }
+}

--- a/src/main/java/project/mbti/exception/IpNotFoundException.java
+++ b/src/main/java/project/mbti/exception/IpNotFoundException.java
@@ -1,0 +1,9 @@
+package project.mbti.exception;
+
+import project.mbti.response.error.ErrorCode;
+
+public class IpNotFoundException extends BusinessException {
+    public IpNotFoundException() {
+        super(ErrorCode.IP_NOT_FOUND);
+    }
+}

--- a/src/main/java/project/mbti/report/ReportRepository.java
+++ b/src/main/java/project/mbti/report/ReportRepository.java
@@ -11,11 +11,12 @@ import project.mbti.report.entity.Report;
 import project.mbti.report.entity.ReportState;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
     @Query("select new project.mbti.report.dto." +
-            "ReportDto(r.id, r.subject, r.description, r.reason, r.state, r.comment.id, r.comment.content, r.comment.state) " +
+            "ReportDto(r.id, r.subject, r.description, r.reason, r.state, r.comment.id, r.comment.content, r.comment.state, r.ip) " +
             "from Report r " +
             "join r.comment c " +
             "where r.state = :state")
@@ -24,4 +25,6 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     @Modifying(clearAutomatically = true)
     @Query("update Report r set r.state = 'CANCELED', r.reason = :reason where r.comment.id = :commentId and r.state = 'REPORTED'")
     void bulkUpdateReportStateByCommentId(@Param("commentId") Long commentId, @Param("reason") String reason);
+
+    Optional<Report> findByIpAndCommentId(String ip, Long commentId);
 }

--- a/src/main/java/project/mbti/report/ReportService.java
+++ b/src/main/java/project/mbti/report/ReportService.java
@@ -1,13 +1,18 @@
 package project.mbti.report;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import project.mbti.block.BlockRepository;
+import project.mbti.block.entity.Block;
 import project.mbti.comment.CommentRepository;
 import project.mbti.exception.AlreadyDeletedCommentException;
 import project.mbti.comment.entity.Comment;
@@ -20,10 +25,14 @@ import project.mbti.report.entity.ReportSubject;
 import javax.persistence.EntityManager;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.springframework.data.domain.Sort.Direction.ASC;
 import static org.springframework.data.domain.Sort.Direction.DESC;
+import static org.springframework.http.HttpMethod.POST;
 import static project.mbti.comment.entity.CommentState.*;
+import static project.mbti.report.dto.ReportWriteResultType.*;
 import static project.mbti.report.entity.ReportState.*;
 
 @Transactional(readOnly = true)
@@ -33,30 +42,53 @@ public class ReportService {
 
     private final ReportRepository reportRepository;
     private final CommentRepository commentRepository;
+    private final BlockRepository blockRepository;
     private final EntityManager em;
 
+    @Value("${webhook.slack.url}")
+    private String url;
+
     @Transactional
-    public ReportSlackDto create(ReportWriteDto dto) {
-        if (dto.getSubject().equals(ReportSubject.NOT_FOUND))
+    public ReportWriteResultType create(ReportSubject subject, String description, Long commentId, String ip) {
+        if (subject.equals(ReportSubject.NOT_FOUND))
             throw new InvalidReportSubjectException();
 
-        final Comment comment = commentRepository.findById(dto.getCommentId()).orElseThrow(CommentNotFoundException::new);
+        ReportWriteResultType result;
+        if (blockRepository.findByIp(ip).isPresent())
+            result = BLOCKED_IP;
+        else if (reportRepository.findByIpAndCommentId(ip, commentId).isPresent())
+            result = ALREADY_EXIST;
+        else {
+            final Comment comment = commentRepository.findById(commentId).orElseThrow(CommentNotFoundException::new);
 
-        final Report report = Report.builder()
-                .comment(comment)
-                .subject(dto.getSubject())
-                .description(dto.getDescription())
-                .build();
+            final Report report = Report.builder()
+                    .comment(comment)
+                    .subject(subject)
+                    .description(description)
+                    .ip(ip)
+                    .build();
 
-        reportRepository.save(report);
+            result = SUCCESS;
+            reportRepository.save(report);
+            postToSlack(subject, description, commentId, comment, report);
+        }
 
-        return ReportSlackDto.builder()
-                .reportId(report.getId())
-                .subject(dto.getSubject())
-                .description(dto.getDescription())
-                .commentId(comment.getId())
-                .commentContent(comment.getContent())
-                .build();
+        return result;
+    }
+
+    private void postToSlack(ReportSubject subject, String description, Long commentId, Comment comment, Report report) {
+        RestTemplate restTemplate = new RestTemplate();
+        Map<String, Object> slackRequest = new HashMap<>();
+        slackRequest.put("text",
+                "🔥🔥 새로운 신고가 접수되었어요! 🔥🔥\n\n" +
+                        "#️⃣ 신고 id: " + report.getId() + "\n" +
+                        "✅ 신고 유형: " + subject.getName() + "\n" +
+                        "😫 신고 사유: " + description + "\n\n" +
+                        "#️⃣ 댓글 id: " + commentId + "\n" +
+                        "🤬 댓글 내용: " + comment.getContent());
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(slackRequest);
+        restTemplate.exchange(url, POST, entity, String.class);
     }
 
     public Page<ReportDto> getReportPage(int page, int size, ReportState state) {
@@ -78,6 +110,7 @@ public class ReportService {
 
         if (dto.getState().equals(COMPLETED)) {
             report.getComment().updateState(DELETED);
+            blockRepository.save(new Block(report.getComment().getIp()));
             em.flush();
             reportRepository.bulkUpdateReportStateByCommentId(report.getComment().getId(), "이미 처리된 신고(id:" + dto.getReportId() + ") - " + LocalDateTime.now());
         }

--- a/src/main/java/project/mbti/report/dto/ReportDto.java
+++ b/src/main/java/project/mbti/report/dto/ReportDto.java
@@ -42,4 +42,7 @@ public class ReportDto {
 
     @ApiModelProperty(value = "댓글 상태", example = "DELETED")
     private CommentState commentState;
+
+    @ApiModelProperty(value = "댓글 작성자 IP", example = "0:0:0:0:0:0:0:1")
+    private String writerIp;
 }

--- a/src/main/java/project/mbti/report/dto/ReportWriteResponseDto.java
+++ b/src/main/java/project/mbti/report/dto/ReportWriteResponseDto.java
@@ -1,0 +1,21 @@
+package project.mbti.report.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@ApiModel(description = "댓글 신고 결과 응답 데이터 모델")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportWriteResponseDto {
+
+    @ApiModelProperty(value = "댓글 신고 결과", example = "SUCCESS")
+    private ReportWriteResultType result;
+
+    @ApiModelProperty(value = "댓글 신고자 IP", example = "111.111.111.111,11.111.11.111")
+    private String clientIp;
+}

--- a/src/main/java/project/mbti/report/dto/ReportWriteResultType.java
+++ b/src/main/java/project/mbti/report/dto/ReportWriteResultType.java
@@ -1,0 +1,5 @@
+package project.mbti.report.dto;
+
+public enum ReportWriteResultType {
+    SUCCESS, BLOCKED_IP, ALREADY_EXIST
+}

--- a/src/main/java/project/mbti/report/entity/Report.java
+++ b/src/main/java/project/mbti/report/entity/Report.java
@@ -47,13 +47,16 @@ public class Report {
     @Column(name = "created_date")
     private LocalDateTime createdDate;
 
+    private String ip;
+
     @Builder
-    public Report(Comment comment, ReportSubject subject, String description) {
+    public Report(Comment comment, ReportSubject subject, String description, String ip) {
         this.comment = comment;
         this.subject = subject;
         this.description = description;
         this.state = ReportState.REPORTED;
         this.reason = "";
+        this.ip = ip;
     }
 
     public void process(ReportState state, String reason) {

--- a/src/main/java/project/mbti/response/error/ErrorCode.java
+++ b/src/main/java/project/mbti/response/error/ErrorCode.java
@@ -27,6 +27,10 @@ public enum ErrorCode {
     INVALID_REPORT_SUBJECT(400, "R002", "유효하지 않은 신고 유형입니다."),
     INVALID_REPORT_STATE(400, "R003", "유효하지 않은 신고 상태입니다."),
     ALREADY_COMPLETED_REPORT(400, "R003", "이미 처리된 신고입니다."),
+
+    // Block
+    ALREADY_BLOCKED_IP(400, "B001", "이미 차단된 IP입니다."),
+    IP_NOT_FOUND(400, "B002", "해당 IP는 차단되어 있지 않습니다."),
     ;
 
     private int status;

--- a/src/main/java/project/mbti/response/result/ResultCode.java
+++ b/src/main/java/project/mbti/response/result/ResultCode.java
@@ -12,15 +12,22 @@ public enum ResultCode {
     DELETE_COMMENT_SUCCESS(200,"C101", "댓글 삭제 성공"),
     FIND_COMMENT_PAGE_SUCCESS(200,"C102", "댓글 페이징 조회 성공"),
     FIND_REPLY_PAGE_SUCCESS(200,"C103", "대댓글 페이징 조회 성공"),
+    WRITE_COMMENT_FAILURE(200,"C104", "댓글 작성 실패"),
 
     // Test
-    GET_TEST_COUNT_SUCCESS(200, "T001", "테스트 참여 횟수 조회 성공"),
-    ANALYSIS_TEST_SUCCESS(200, "T002", "테스트 분석 성공"),
+    GET_TEST_COUNT_SUCCESS(200, "T100", "테스트 참여 횟수 조회 성공"),
+    ANALYSIS_TEST_SUCCESS(200, "T101", "테스트 분석 성공"),
 
     // Report
-    WRITE_REPORT_SUCCESS(200, "R001", "댓글 신고 성공"),
-    FIND_REPORT_PAGE_SUCCESS(200, "R002", "신고 페이징 조회 성공"),
-    PROCESS_REPORT_SUCCESS(200, "R003", "신고 처리 성공"),
+    WRITE_REPORT_SUCCESS(200, "R100", "댓글 신고 성공"),
+    FIND_REPORT_PAGE_SUCCESS(200, "R101", "신고 페이징 조회 성공"),
+    PROCESS_REPORT_SUCCESS(200, "R102", "신고 처리 성공"),
+    WRITE_REPORT_FAILURE(200, "R103", "댓글 신고 실패"),
+
+    // Block
+    BLOCK_IP_SUCCESS(200, "B100", "IP 차단 성공"),
+    UNBLOCK_IP_SUCCESS(200, "B101", "IP 차단 해제 성공"),
+    FIND_BLOCK_PAGE_SUCCESS(200, "B102", "IP 차단목록 페이징 조회 성공"),
     ;
 
     private int status;

--- a/src/test/java/project/mbti/comment/CommentControllerTest.java
+++ b/src/test/java/project/mbti/comment/CommentControllerTest.java
@@ -15,6 +15,7 @@ import project.mbti.MBTI;
 import project.mbti.comment.dto.CommentDeleteDto;
 import project.mbti.comment.dto.CommentDto;
 import project.mbti.comment.dto.CommentWriteDto;
+import project.mbti.comment.dto.CommentWriteResultType;
 import project.mbti.comment.entity.Comment;
 import project.mbti.comment.entity.CommentState;
 import project.mbti.exception.CommentNameNotMatchException;
@@ -66,7 +67,7 @@ class CommentControllerTest {
 
         CommentWriteDto commentWriteDto = new CommentWriteDto(MBTI.ISTJ, "만두", "1234", "댓글");
 
-        doReturn(comment).when(commentService).create(comment.getMbti(), comment.getName(), comment.getPassword(), comment.getContent(), 0L);
+        doReturn(CommentWriteResultType.SUCCESS).when(commentService).create(comment.getMbti(), comment.getName(), comment.getPassword(), comment.getContent(), 0L, "127.0.0.1");
 
         // when
         final ResultActions perform = mockMvc.perform(
@@ -94,7 +95,7 @@ class CommentControllerTest {
 
         CommentWriteDto commentWriteDto = new CommentWriteDto(MBTI.NOT_FOUND, "만두", "1234", "댓글");
 
-        doThrow(new InvalidMbtiException()).when(commentService).create(comment.getMbti(), comment.getName(), comment.getPassword(), comment.getContent(), 0L);
+        doThrow(new InvalidMbtiException()).when(commentService).create(comment.getMbti(), comment.getName(), comment.getPassword(), comment.getContent(), 0L, "127.0.0.1");
 
         // when
         final ResultActions perform = mockMvc.perform(

--- a/src/test/java/project/mbti/comment/CommentIntegrationTest.java
+++ b/src/test/java/project/mbti/comment/CommentIntegrationTest.java
@@ -9,9 +9,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
 import org.springframework.transaction.annotation.Transactional;
 import project.mbti.MBTI;
-import project.mbti.comment.dto.CommentDeleteDto;
-import project.mbti.comment.dto.CommentDto;
-import project.mbti.comment.dto.CommentWriteDto;
+import project.mbti.comment.dto.*;
 import project.mbti.comment.entity.CommentState;
 import project.mbti.response.error.ErrorResponse;
 import project.mbti.response.result.ResultResponse;
@@ -43,18 +41,12 @@ public class CommentIntegrationTest {
 
         // when
         ResponseEntity<ResultResponse> response = restTemplate.postForEntity(url, request, ResultResponse.class);
-        final CommentDto commentDto = objectMapper.convertValue(response.getBody().getData(), CommentDto.class);
+        final CommentWriteResponseDto commentWriteResponseDto = objectMapper.convertValue(response.getBody().getData(), CommentWriteResponseDto.class);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getCode()).isEqualTo("C100");
-        assertThat(commentDto.getId()).isEqualTo(1L);
-        assertThat(commentDto.getName()).isEqualTo(dto.getName());
-        assertThat(commentDto.getPassword()).isEqualTo(dto.getPassword());
-        assertThat(commentDto.getContent()).isEqualTo(dto.getContent());
-        assertThat(commentDto.getMbti()).isEqualTo(dto.getMbti());
-        assertThat(commentDto.getChildSize()).isEqualTo(0);
-        assertThat(commentDto.getCreatedDate()).isNotNull();
+        assertThat(commentWriteResponseDto.getResult()).isEqualTo(CommentWriteResultType.SUCCESS);
     }
 
     @Test


### PR DESCRIPTION
### 변경 사항
- 댓글, 신고 Entity에 `ip 필드` 추가
- 차단 API 구현
   - 차단 Entity 생성
   - `IP 차단 API`
   - `IP 차단 목록 페이징 조회 API`
   - `IP 차단 해제 API`
   - 차단 관련 비즈니스 예외
- 댓글API, 신고API에 IP 차단 로직 추가
   - Slack에 메시지 보내는 로직 Service 단으로 이동
   - 댓글, 신고 작성 시 클라이언트 IP도 함께 저장 + 응답 데이터에 결과 반환
   - 댓글 신고할 때, IP 이용 중복 신고 방지 로직 추가
   - 신고 처리할 때, 해당 댓글 작성자의 IP 차단하는 로직 추가
- 댓글 Entity와 댓글 API 로직 수정에 따른 테스트 코드 수정
- 에러, 응답 코드 추가

Resolves: #36 #47 #48 #49 #50 
